### PR TITLE
Fix Makefile to allow CROSS_COMPILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,9 +205,6 @@ ifeq ($(HOSTARCH),$(ARCH))
 CROSS_COMPILE ?=
 endif
 
-CROSS_COMPILE_PATH = /opt/buildroot-gcc463_arm/usr/bin
-CROSS_COMPILE = $(CROSS_COMPILE_PATH)/arm-buildroot-linux-uclibcgnueabi-
-
 # SHELL used by kbuild
 CONFIG_SHELL := $(shell if [ -x "$$BASH" ]; then echo $$BASH; \
 	  else if [ -x /bin/bash ]; then echo /bin/bash; \

--- a/include/linux/compiler-gcc7.h
+++ b/include/linux/compiler-gcc7.h
@@ -1,0 +1,1 @@
+compiler-gcc6.h


### PR DESCRIPTION
Don't overwrite CROSS_COMPILE variable within Makefile, otherwise
the cross-compiler is fixed which breaks common cross-compiling
support.

Signed-off-by: Andreas Reichel <homebase_ar@web.de>